### PR TITLE
Add frame_step argument, fix bitwise shift in pack_rgba, publish single-channel instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Your `scenenn_data` folder structure should be at the end as follows:
 
     ```bash
     cd scenenn_ros_tools && chmod +x nodes/scenenn_to_rosbag.py
-    rosrun scenenn_ros_tools scenenn_to_rosbag.py -scenenn_data_folder PATH/TO/scenenn_data -scene_id SCENE_ID -to_frame TO_FRAME -output_bag OUTPUT_BAG
+    rosrun scenenn_ros_tools scenenn_to_rosbag.py -scenenn_data_folder PATH/TO/scenenn_data -scene_id SCENE_ID -to_frame TO_FRAME -frame_step FRAME_STEP -output_bag OUTPUT_BAG
     ```
 
     For example:
     ```bash
-    rosrun scenenn_ros_tools scenenn_to_rosbag.py -scenenn_data_folder ../../../scenenn/download/scenenn_data/ -scene_id 066 -output_bag scenenn_066.bag
+    rosrun scenenn_ros_tools scenenn_to_rosbag.py -scenenn_data_folder ../../../scenenn/download/scenenn_data/ -scene_id 066 -frame_step 1 -output_bag scenenn_066.bag
     ```

--- a/nodes/scenenn_to_rosbag.py
+++ b/nodes/scenenn_to_rosbag.py
@@ -244,7 +244,7 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
         except KeyError:
             # The trajectory log file sometimes does not contain information
             # for the last frames, which should therefore be ignored.
-            pass
+            break
         publishTransform(transform, timestamp, frame_id, output_bag)
         header.stamp = timestamp
 
@@ -261,6 +261,8 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
         instance_image = pack_rgba(
             instance_image_rgb[:, :, 0], instance_image_rgb[:, :, 1],
             instance_image_rgb[:, :, 2], instance_image_rgb[:, :, 3])
+        # From 8-bit unsigned to 16-bit unsigned.
+        instance_image_gray = np.uint16(instance_image)
 
         # TODO(ff): Add an option to match the labeled image to the RGB/depth
         # image. Either a static offset or probably better some optimization
@@ -330,7 +332,7 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
                                  timestamp)
             else:
                 gray_instance_msg = cvbridge.cv2_to_imgmsg(
-                    instance_image, "mono8")
+                    instance_image_gray, "16UC1")
                 gray_instance_msg.header = header
                 output_bag.write('/camera/instances/image_raw', gray_instance_msg,
                                  timestamp)

--- a/nodes/scenenn_to_rosbag.py
+++ b/nodes/scenenn_to_rosbag.py
@@ -99,12 +99,12 @@ def pack_bgr(red, green, blue):
 def pack_rgba(red, green, blue, alpha):
     # Pack the 4 RGBA channels into a single UINT32 field.
     return np.bitwise_or(
-        np.left_shift(red.astype(np.uint8), 24),
+        np.left_shift(red.astype(np.uint32), 24),
         np.bitwise_or(
-            np.left_shift(green.astype(np.uint8), 16),
+            np.left_shift(green.astype(np.uint32), 16),
             np.bitwise_or(
-                np.left_shift(blue.astype(np.uint8), 8), alpha.astype(
-                    np.uint8))))
+                np.left_shift(blue.astype(np.uint32), 8), alpha.astype(
+                    np.uint32))))
 
 
 def parse_timestamps(scenenn_path, scene):

--- a/nodes/scenenn_to_rosbag.py
+++ b/nodes/scenenn_to_rosbag.py
@@ -216,7 +216,7 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
     rospy.init_node('scenenn_node', anonymous=True)
     frame_id = "/scenenn_camera_frame"
 
-    publish_object_segments = False
+    publish_object_segments = True
     publish_scene_pcl = True
     publish_rgbd = True
     publish_instances = True

--- a/nodes/scenenn_to_rosbag.py
+++ b/nodes/scenenn_to_rosbag.py
@@ -258,9 +258,6 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
         instance_image_rgb = cv2.imread(
             instance_path_from_frame(scenenn_path, scene, frame),
             cv2.IMREAD_UNCHANGED)
-        instance_image_gray = cv2.imread(
-            instance_path_from_frame(scenenn_path, scene, frame),
-            cv2.IMREAD_GRAYSCALE)
         instance_image = pack_rgba(
             instance_image_rgb[:, :, 0], instance_image_rgb[:, :, 1],
             instance_image_rgb[:, :, 2], instance_image_rgb[:, :, 3])
@@ -333,7 +330,7 @@ def publish(scenenn_path, scene, output_bag, frame_step, to_frame):
                                  timestamp)
             else:
                 gray_instance_msg = cvbridge.cv2_to_imgmsg(
-                    instance_image_gray, "mono8")
+                    instance_image, "mono8")
                 gray_instance_msg.header = header
                 output_bag.write('/camera/instances/image_raw', gray_instance_msg,
                                  timestamp)

--- a/nodes/scenenn_to_rosbag.py
+++ b/nodes/scenenn_to_rosbag.py
@@ -220,6 +220,7 @@ def publish(scenenn_path, scene, output_bag, to_frame):
     publish_scene_pcl = True
     publish_rgbd = True
     publish_instances = True
+    publish_instances_color = False
 
     # Set camera information and model.
     camera_info = parse_camera_info(scenenn_path)
@@ -252,6 +253,9 @@ def publish(scenenn_path, scene, output_bag, to_frame):
         instance_image_rgb = cv2.imread(
             instance_path_from_frame(scenenn_path, scene, frame),
             cv2.IMREAD_UNCHANGED)
+        instance_image_gray = cv2.imread(
+            instance_path_from_frame(scenenn_path, scene, frame),
+            cv2.IMREAD_GRAYSCALE)
         instance_image = pack_rgba(
             instance_image_rgb[:, :, 0], instance_image_rgb[:, :, 1],
             instance_image_rgb[:, :, 2], instance_image_rgb[:, :, 3])
@@ -316,11 +320,18 @@ def publish(scenenn_path, scene, output_bag, to_frame):
 
         if (publish_instances):
             # Publish the instance data.
-            color_instance_msg = cvbridge.cv2_to_imgmsg(
-                instance_image_rgb, "8UC4")
-            color_instance_msg.header = header
-            output_bag.write('/camera/instances/image_raw', color_instance_msg,
-                             timestamp)
+            if (publish_instances_color):
+                color_instance_msg = cvbridge.cv2_to_imgmsg(
+                    instance_image_rgb, "8UC4")
+                color_instance_msg.header = header
+                output_bag.write('/camera/instances/image_raw', color_instance_msg,
+                                 timestamp)
+            else:
+                gray_instance_msg = cvbridge.cv2_to_imgmsg(
+                    instance_image_gray, "mono8")
+                gray_instance_msg.header = header
+                output_bag.write('/camera/instances/image_raw', gray_instance_msg,
+                                 timestamp)
         print("Dataset timestamp: " + '{:4}'.format(timestamp.secs) + "." +
               '{:09}'.format(timestamp.nsecs) + "     Frame: " +
               '{:3}'.format(frame) + " / " + str(len(timestamps)))


### PR DESCRIPTION
Allow to skip frames when generating the rosbag, fix precision in bitwise shift in function pack_rgba. Allow to publish single-channel instances as an alternative to color instances. Also, handle the final frames - for which no information is available in the trajectory log files - by terminating early, instead of throwing a KeyError.